### PR TITLE
docs(index): add links to rust and c tutorial

### DIFF
--- a/pages/docs/index.mdx
+++ b/pages/docs/index.mdx
@@ -65,8 +65,8 @@ Writing programs that use WASIX is very similar to writing normal programs in la
 
 WASIX currently supports the following languages:
 
-- Rust (link to rust specific guide for examples with Rust)
-- C (link to C specific guide for examples with C)
+- [Rust](/docs/language-guide/rust/installation)
+- [C](/docs/language-guide/c/installation)
 - Zig
 - AssemblyScript (Support coming soon)
 


### PR DESCRIPTION
connected the links for supported languages in index page `How to use WASIX ?`