### PR TITLE
Fixes build example

### DIFF
--- a/pages/docs/language-guide/rust/usage.mdx
+++ b/pages/docs/language-guide/rust/usage.mdx
@@ -26,7 +26,7 @@ $ cargo wasix test <path-to-wasm-file>
 ### Building a binary
 
 ```shell copy
-$ cargo wasix build <path-to-wasm-file>
+$ cargo wasix build
 ```
 
 ### Benchmarking a binary


### PR DESCRIPTION
cargo wasix build command doesn't take the wasm file path as an arg