### PR TITLE
Clarifies wasix toolchain installation

### DIFF
--- a/pages/docs/language-guide/rust/installation.mdx
+++ b/pages/docs/language-guide/rust/installation.mdx
@@ -30,7 +30,9 @@ $ cargo wasix --version
 cargo-wasix 0.1.17
 ```
 
-Check that the `wasix` toolchain was installed correctly by running:
+`wasix` toolchain will be installed when you first run a commad that requires it, like `cargo wasix check` or `cargo wasix build`.
+
+Once it is installed you can check by running:
 
 ```shell
 $ rustup toolchain list | grep wasix


### PR DESCRIPTION
Clarifies that wasix toolchain is installed when you first run a command that requires it

You can not verify wasix toolchain is installed right after running cargo install cargo-wasix because this command does not install wasix toolchain. You need to run a command that requires the toolchain for it to be installed. Just after that you could verify the toolchain is installed with rustup toolchain list